### PR TITLE
Fix for resolution check

### DIFF
--- a/library/src/main/java/net/ossrs/yasea/SrsCameraView.java
+++ b/library/src/main/java/net/ossrs/yasea/SrsCameraView.java
@@ -87,7 +87,7 @@ public class SrsCameraView extends SurfaceView implements SurfaceHolder.Callback
 
         Camera.Parameters params = mCamera.getParameters();
         Camera.Size size = mCamera.new Size(previewWidth, previewHeight);
-        if (!params.getSupportedPreviewSizes().contains(size) || !params.getSupportedPictureSizes().contains(size)) {
+        if (!params.getSupportedPreviewSizes().contains(size) || !params.getSupportedVideoSizes().contains(size)) {
             Toast.makeText(getContext(), String.format("Unsupported resolution %dx%d", size.width, size.height), Toast.LENGTH_SHORT).show();
             stopCamera();
             return false;


### PR DESCRIPTION
This line was checking for picture supporte sizes and not video. In my case I have a Galaxy Camera 2 which does not support 1280x720 for pics but does for video.