### PR TITLE
Fix for video not being sent

### DIFF
--- a/library/src/main/java/net/ossrs/yasea/SrsCameraView.java
+++ b/library/src/main/java/net/ossrs/yasea/SrsCameraView.java
@@ -78,6 +78,7 @@ public class SrsCameraView extends SurfaceView implements SurfaceHolder.Callback
         Camera.Parameters params = mCamera.getParameters();
         int[] range = adaptPreviewFps(SrsEncoder.VFPS, params.getSupportedPreviewFpsRange());
         params.setPreviewFpsRange(range[0], range[1]);
+        params.setPreviewSize(mPreviewWidth, mPreviewHeight);
         params.setPreviewFormat(ImageFormat.NV21);
         params.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
         params.setWhiteBalance(Camera.Parameters.WHITE_BALANCE_AUTO);


### PR DESCRIPTION
This line was needed since just below the params of the camera object are being replaced.  Method setPreviewResolution does set the preview resolution in the current params of the camera, but those get replaced in this method.

