### PR TITLE
change the pts value to avoid it becomes negative.

### DIFF
--- a/library/src/main/java/net/ossrs/yasea/SrsFlvMuxer.java
+++ b/library/src/main/java/net/ossrs/yasea/SrsFlvMuxer.java
@@ -812,7 +812,7 @@ public class SrsFlvMuxer {
         }
 
         public void writeAudioSample(final ByteBuffer bb, MediaCodec.BufferInfo bi) {
-            int pts = (int)(bi.presentationTimeUs / 1000);
+            int pts = ((int) (bi.presentationTimeUs / 1000)) & 0x7fffffff;
             int dts = pts;
 
             byte[] frame = new byte[bi.size + 2];
@@ -931,7 +931,7 @@ public class SrsFlvMuxer {
         }
 
         public void writeVideoSample(final ByteBuffer bb, MediaCodec.BufferInfo bi) {
-            int pts = (int)(bi.presentationTimeUs / 1000);
+            int pts = ((int) (bi.presentationTimeUs / 1000)) & 0x7fffffff;
             int dts = (int)pts;
 
             ArrayList<SrsFlvFrameBytes> ibps = new ArrayList<SrsFlvFrameBytes>();


### PR DESCRIPTION
Fix a bug that the pts value maybe negative when the long type is converted to int,it will cause invalid data error.