### PR TITLE
fix C2 may not send during rtmp handshake

### DIFF
--- a/library/src/main/java/com/github/faucamp/simplertmp/io/RtmpConnection.java
+++ b/library/src/main/java/com/github/faucamp/simplertmp/io/RtmpConnection.java
@@ -94,6 +94,7 @@ public class RtmpConnection implements RtmpPublisher {
         handshake.readS0(in);
         handshake.readS1(in);
         handshake.writeC2(out);
+        out.flush();
         handshake.readS2(in);
     }
 

--- a/library/src/main/java/com/github/faucamp/simplertmp/packets/Handshake.java
+++ b/library/src/main/java/com/github/faucamp/simplertmp/packets/Handshake.java
@@ -162,7 +162,7 @@ public final class Handshake {
 
     /** Generates and writes the third handshake packet (C2) */
     public final void writeC2(OutputStream out) throws IOException {
-        Log.d(TAG, "readC2");
+        Log.d(TAG, "writeC2");
         // C2 is an echo of S1
         if (s1 == null) {
             throw new IllegalStateException("C2 cannot be written without S1 being read first");


### PR DESCRIPTION
I found a tiny issue when I publish a live stream via yasea a on my local side, the NG summary packet like below:
742	2018/004 10:49:45.372509	172.16.66.20	172.16.110.30	RTMP	131	Handshake C0+C1
743	2018/004 10:49:45.372639	172.16.110.30	172.16.66.20	TCP	54	1935 → 47493 [ACK] Seq=1 Ack=1538 Win=65536 Len=0
744	2018/004 10:49:45.372941	172.16.110.30	172.16.66.20	TCP	1514	1935 → 47493 [ACK] Seq=1 Ack=1538 Win=65536 Len=1460
745	2018/004 10:49:45.372962	172.16.110.30	172.16.66.20	TCP	1514	1935 → 47493 [ACK] Seq=1461 Ack=1538 Win=65536 Len=1460
746	2018/004 10:49:45.372970	172.16.110.30	172.16.66.20	RTMP	207	Handshake S0+S1+S2
747	2018/004 10:49:45.375596	172.16.66.20	172.16.110.30	TCP	60	47493 → 1935 [ACK] Seq=1538 Ack=1461 Win=90624 Len=0
748	2018/004 10:49:45.376978	172.16.66.20	172.16.110.30	TCP	60	47493 → 1935 [ACK] Seq=1538 Ack=2921 Win=93440 Len=0
749	2018/004 10:49:45.377756	172.16.66.20	172.16.110.30	TCP	60	47493 → 1935 [ACK] Seq=1538 Ack=3074 Win=93440 Len=0
750	2018/004 10:49:45.380986	172.16.66.20	172.16.110.30	TCP	1514	47493 → 1935 [ACK] Seq=1538 Ack=3074 Win=93440 Len=1460
751	2018/004 10:49:45.380991	172.16.66.20	172.16.110.30	RTMP	399	connect('teach_app')

C2 packet seems to disappear. the reason that I think it's a tiny issue is the rtmp Netconnection and NetStream can setup successfully.