### PR TITLE
修复软编码时概率性崩溃（前帧的BufferInfo参数被后帧所覆盖，byteBuffer无法执行limit(int newlimit)方法）

### DIFF
--- a/library/src/main/java/net/ossrs/yasea/SrsEncoder.java
+++ b/library/src/main/java/net/ossrs/yasea/SrsEncoder.java
@@ -320,6 +320,7 @@ public class SrsEncoder {
 
     private void onSoftEncodedData(byte[] es, long pts, boolean isKeyFrame) {
         ByteBuffer bb = ByteBuffer.wrap(es);
+        MediaCodec.BufferInfo vebi = new MediaCodec.BufferInfo();
         vebi.offset = 0;
         vebi.size = es.length;
         vebi.presentationTimeUs = pts;

--- a/library/src/main/java/net/ossrs/yasea/SrsEncoder.java
+++ b/library/src/main/java/net/ossrs/yasea/SrsEncoder.java
@@ -47,8 +47,6 @@ public class SrsEncoder {
     private MediaCodecInfo vmci;
     private MediaCodec vencoder;
     private MediaCodec aencoder;
-    private MediaCodec.BufferInfo vebi = new MediaCodec.BufferInfo();
-    private MediaCodec.BufferInfo aebi = new MediaCodec.BufferInfo();
 
     private boolean networkWeakTriggered = false;
     private boolean mCameraFaceFront = true;
@@ -307,6 +305,7 @@ public class SrsEncoder {
         }
 
         for (; ; ) {
+            MediaCodec.BufferInfo vebi = new MediaCodec.BufferInfo();
             int outBufferIndex = vencoder.dequeueOutputBuffer(vebi, 0);
             if (outBufferIndex >= 0) {
                 ByteBuffer bb = outBuffers[outBufferIndex];
@@ -358,6 +357,7 @@ public class SrsEncoder {
             }
 
             for (; ; ) {
+                MediaCodec.BufferInfo aebi = new MediaCodec.BufferInfo();
                 int outBufferIndex = aencoder.dequeueOutputBuffer(aebi, 0);
                 if (outBufferIndex >= 0) {
                     ByteBuffer bb = outBuffers[outBufferIndex];


### PR DESCRIPTION
异常抛出位置如下
![qq 20180612154545](https://user-images.githubusercontent.com/8803478/41277579-30479f54-6e5a-11e8-9d97-b10309af68eb.png)
