### PR TITLE
Added 'isAllFramesUploaded' and 'getVideoFrameCacheCount' methods.

### DIFF
--- a/library/src/main/java/net/ossrs/yasea/SrsPublisher.java
+++ b/library/src/main/java/net/ossrs/yasea/SrsPublisher.java
@@ -218,6 +218,17 @@ public class SrsPublisher {
         }
     }
 
+    public boolean isAllFramesUploaded(){
+        return mFlvMuxer.getVideoFrameCacheNumber().get() == 0;
+    }
+
+    public int getVideoFrameCacheCount(){
+        if(mFlvMuxer != null) {
+            return mFlvMuxer.getVideoFrameCacheNumber().get();
+        }
+        return 0;
+    }
+
     public void switchToSoftEncoder() {
         mEncoder.switchToSoftEncoder();
     }


### PR DESCRIPTION
'isAllFramesUploaded' : Boolean - Return if all frames are uploaded on server from cache. 
'getVideoFrameCacheCount' : Number - Return the remaining frame counts in cache as discussed here #393 .

So in this way user can do some action for remaining stream before disconnecting to RTMP server. 