### PR TITLE
adjusting timestamps when hot switching the camera

### DIFF
--- a/library/src/main/java/net/ossrs/yasea/SrsPublisher.java
+++ b/library/src/main/java/net/ossrs/yasea/SrsPublisher.java
@@ -309,6 +309,11 @@ public class SrsPublisher {
     }
 
     public void switchCameraFace(int id) {
+        
+        if (mEncoder != null && mEncoder.isEnabled()) {
+            mEncoder.pause();
+        }        
+        
         mCameraView.stopCamera();
         mCameraView.setCameraId(id);
         if (id == 0) {
@@ -320,6 +325,11 @@ public class SrsPublisher {
             mCameraView.enableEncoding();
         }
         mCameraView.startCamera();
+        
+        if (mEncoder != null && mEncoder.isEnabled()) {
+            mEncoder.resume();
+        }        
+        
     }
 
     public void setRtmpHandler(RtmpHandler handler) {


### PR DESCRIPTION
When switching cameras, the encoders must be paused. Otherwise, there will be problems with the DTS on the client,  SRS  server with enabled time_jitter incorrectly corrects video DTS (with enabled ATC  there is no problem)